### PR TITLE
fix(project): remove outdated live linting option for eslint & stylelint

### DIFF
--- a/packages/generator-nitro/generators/app/templates/config/default.js
+++ b/packages/generator-nitro/generators/app/templates/config/default.js
@@ -10,9 +10,6 @@ const baseConfig = require('@nitro/app/app/core/config');
 const defaultConfig = {
 	code: {
 		validation: {
-			eslint: {
-				live: false,
-			},
 			htmllint: {
 				// enabling this live validation slows down rendering
 				live: false,
@@ -21,9 +18,6 @@ const defaultConfig = {
 				live: true,
 				logMissingSchemaAsError: false,
 				logMissingSchemaAsWarning: true,
-			},
-			stylelint: {
-				live: false,
 			},
 		},
 	},

--- a/packages/generator-nitro/generators/app/templates/config/webpack/options.js
+++ b/packages/generator-nitro/generators/app/templates/config/webpack/options.js
@@ -4,12 +4,9 @@ const theme = process.env.THEME ? process.env.THEME : validThemes.find((theme) =
 const options = {
 	rules: {
 		<% if (options.jsCompiler === 'ts') { %>js: false,
-		ts: true,<% } else { %>js: {
-			eslint: config.get('code.validation.eslint.live'),
-		},
+		ts: true,<% } else { %>js: true,
 		ts: false,<% } %>
-		scss: {
-			stylelint: config.get('code.validation.stylelint.live'),<% if (options.themes) { %>
+		scss: {<% if (options.themes) { %>
 			implementation: require('node-sass'),<% } %>
 		},
 		hbs: <% if (options.clientTpl) { %>true<% } else { %>false<% } %>,

--- a/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
+++ b/packages/generator-nitro/generators/app/templates/project/docs/nitro-config.md
@@ -12,14 +12,6 @@ the main nodes from nitro: `code`, `nitro`,`server`, `gulp`, `feature`, `exporte
 
 ### Validation
 
-#### `code.validation.eslint`
-
-Type: Object
-
-- `code.validation.eslint.live` - default: false
-
-Enable/disable JavaScript linting on change.
-
 #### `code.validation.htmllint`
 
 Type: Object
@@ -36,14 +28,6 @@ Type: Object
   Enable/disable JSON-Schema validation on change.
 - `code.validation.jsonSchema.logMissingSchemaAsError` - default: false
 - `code.validation.jsonSchema.logMissingSchemaAsWarning` - default: true
-
-#### `code.validation.stylelint`
-
-Type: Object
-
-- `code.validation.stylelint.live` - default: false
-
-Enable/disable CSS linting on change.
 
 ## Nitro
 

--- a/packages/nitro-app/app/core/config.js
+++ b/packages/nitro-app/app/core/config.js
@@ -30,16 +30,10 @@ const defaultConfig = {
 	},
 	code: {
 		validation: {
-			eslint: {
-				live: true,
-			},
 			htmllint: {
 				live: true,
 			},
 			jsonSchema: {
-				live: true,
-			},
-			stylelint: {
 				live: true,
 			},
 		},

--- a/packages/nitro-webpack/package.json
+++ b/packages/nitro-webpack/package.json
@@ -32,9 +32,6 @@
     "autoprefixer": "10.4.14",
     "case-sensitive-paths-webpack-plugin": "2.4.0",
     "css-loader": "5.2.7",
-    "eslint": "7.32.0",
-    "eslint-webpack-plugin": "2.7.0",
-    "eslint-plugin-import": "2.27.5",
     "file-loader": "6.2.0",
     "handlebars-loader": "1.7.3",
     "iconfont-webpack-plugin": "5.0.1",
@@ -48,8 +45,6 @@
     "resolve-url-loader": "5.0.0",
     "sass": "1.60.0",
     "sass-loader": "10.4.1",
-    "stylelint": "14.16.1",
-    "stylelint-webpack-plugin": "2.4.0",
     "svgo": "3.0.2",
     "ts-config-webpack-plugin": "2.0.3",
     "typescript": "4.9.5",
@@ -65,7 +60,9 @@
     "imagemin-svgo": "9.0.0"
   },
   "devDependencies": {
-    "@merkle-open/eslint-config": "1.0.0"
+    "@merkle-open/eslint-config": "1.0.0",
+    "eslint": "7.32.0",
+    "eslint-plugin-import": "2.27.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nitro-webpack/readme.md
+++ b/packages/nitro-webpack/readme.md
@@ -11,13 +11,9 @@ Configurable and easy to use webpack 4 config for nitro projects.
 ```
 const options = {
     rules: {
-        js: {
-            eslint: false,
-        },
+        js: true,
         ts: false,
-        scss: {
-            stylelint: false,
-        },
+        scss: true,
         hbs: true,
         woff: true,
         font: false,
@@ -50,7 +46,6 @@ No loader rule is enabled by default. Activate following prepared rules you need
 Config:
 
 - `true` or `{}` activates JavaScript support
-- `{ eslint: true }` additionally adds eslint live linting feature (only relevant for development build)
 
 #### `options.rules.ts`
 
@@ -71,7 +66,6 @@ Config:
 Config:
 
 - `true` or `{}` will activate scss support
-- `{ stylelint: true }` additionally adds stylelint live linting feature (only relevant for development build)
 - `{ publicPath: '../' }` provide a separate public path for stylesheets. By default, webpack uses the value from 'output.publicPath'. (only relevant for production build)
 - `{ implementation: require('node-sass') }` gives the possibility to use 'node-sass' as sass implementation. (you have to add 'node-sass' as a dev-dependency in your project)
 
@@ -112,7 +106,7 @@ Config:
 - `{ exclude: [] }` additionally adds exclude config to rule
 
 ⚠ Please use this rule with care. You have to configure includes and exclude when you also use woff and/or image loader.
-Otherwise svg or woff files are processed with multiple configurations.
+Otherwise, svg or woff files are processed with multiple configurations.
 
 #### `options.rules.image`
 

--- a/packages/nitro-webpack/webpack-config/webpack.config.dev.js
+++ b/packages/nitro-webpack/webpack-config/webpack.config.dev.js
@@ -4,10 +4,8 @@ const crypto = require('crypto');
 const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-const ESLintPlugin = require('eslint-webpack-plugin');
 const JsConfigWebpackPlugin = require('js-config-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const StyleLintPlugin = require('stylelint-webpack-plugin');
 const TsConfigWebpackPlugin = require('ts-config-webpack-plugin');
 const DynamicAliasResolverPlugin = require('../plugins/dynamicAliasResolver');
 const utils = require('../lib/utils');
@@ -108,14 +106,6 @@ module.exports = (options = { rules: {}, features: {} }) => {
 	// js
 	if (options.rules.js) {
 		webpackConfig.plugins.push(new JsConfigWebpackPlugin({ babelConfigFile: './babel.config.js' }));
-
-		// eslint live validation
-		if (options.rules.js.eslint) {
-			const esLintPluginOptions = {
-				lintDirtyModulesOnly: true,
-			};
-			webpackConfig.plugins.push(new ESLintPlugin(esLintPluginOptions));
-		}
 	}
 
 	// typescript
@@ -182,20 +172,6 @@ module.exports = (options = { rules: {}, features: {} }) => {
 				filename: '[file].map',
 			})
 		);
-
-		// stylelint live validation
-		if (options.rules.scss.stylelint) {
-			webpackConfig.plugins.push(
-				new StyleLintPlugin({
-					files: ['src/**/*.?(s)css'],
-					// lintDirtyModulesOnly: true,
-					syntax: 'scss',
-					quiet: false,
-					failOnError: false,
-					emitErrors: true,
-				})
-			);
-		}
 	}
 
 	// handlebars precompiled templates

--- a/packages/project-nitro-twig/config/default.js
+++ b/packages/project-nitro-twig/config/default.js
@@ -10,9 +10,6 @@ const baseConfig = require('@nitro/app/app/core/config');
 const defaultConfig = {
 	code: {
 		validation: {
-			eslint: {
-				live: false,
-			},
 			htmllint: {
 				// enabling this live validation slows down rendering
 				live: false,
@@ -21,9 +18,6 @@ const defaultConfig = {
 				live: true,
 				logMissingSchemaAsError: false,
 				logMissingSchemaAsWarning: true,
-			},
-			stylelint: {
-				live: false,
 			},
 		},
 	},

--- a/packages/project-nitro-twig/config/webpack/options.js
+++ b/packages/project-nitro-twig/config/webpack/options.js
@@ -1,13 +1,9 @@
 const config = require('config');
 const options = {
 	rules: {
-		js: {
-			eslint: config.get('code.validation.eslint.live'),
-		},
+		js: true,
 		ts: false,
-		scss: {
-			stylelint: config.get('code.validation.stylelint.live'),
-		},
+		scss: true,
 		hbs: true,
 		woff: true,
 		image: true,

--- a/packages/project-nitro-twig/project/docs/nitro-config.md
+++ b/packages/project-nitro-twig/project/docs/nitro-config.md
@@ -12,14 +12,6 @@ the main nodes from nitro: `code`, `nitro`,`server`, `gulp`, `feature`, `exporte
 
 ### Validation
 
-#### `code.validation.eslint`
-
-Type: Object
-
-- `code.validation.eslint.live` - default: false
-
-Enable/disable JavaScript linting on change.
-
 #### `code.validation.htmllint`
 
 Type: Object
@@ -36,14 +28,6 @@ Type: Object
   Enable/disable JSON-Schema validation on change.
 - `code.validation.jsonSchema.logMissingSchemaAsError` - default: false
 - `code.validation.jsonSchema.logMissingSchemaAsWarning` - default: true
-
-#### `code.validation.stylelint`
-
-Type: Object
-
-- `code.validation.stylelint.live` - default: false
-
-Enable/disable CSS linting on change.
 
 ## Nitro
 

--- a/packages/project-nitro-typescript/config/default.js
+++ b/packages/project-nitro-typescript/config/default.js
@@ -10,9 +10,6 @@ const baseConfig = require('@nitro/app/app/core/config');
 const defaultConfig = {
 	code: {
 		validation: {
-			eslint: {
-				live: false,
-			},
 			htmllint: {
 				// enabling this live validation slows down rendering
 				live: false,
@@ -21,9 +18,6 @@ const defaultConfig = {
 				live: true,
 				logMissingSchemaAsError: false,
 				logMissingSchemaAsWarning: true,
-			},
-			stylelint: {
-				live: false,
 			},
 		},
 	},

--- a/packages/project-nitro-typescript/config/webpack/options.js
+++ b/packages/project-nitro-typescript/config/webpack/options.js
@@ -3,9 +3,7 @@ const options = {
 	rules: {
 		js: false,
 		ts: true,
-		scss: {
-			stylelint: config.get('code.validation.stylelint.live'),
-		},
+		scss: true,
 		hbs: true,
 		woff: true,
 		image: true,

--- a/packages/project-nitro-typescript/project/docs/nitro-config.md
+++ b/packages/project-nitro-typescript/project/docs/nitro-config.md
@@ -12,14 +12,6 @@ the main nodes from nitro: `code`, `nitro`,`server`, `gulp`, `feature`, `exporte
 
 ### Validation
 
-#### `code.validation.eslint`
-
-Type: Object
-
-- `code.validation.eslint.live` - default: false
-
-Enable/disable JavaScript linting on change.
-
 #### `code.validation.htmllint`
 
 Type: Object
@@ -36,14 +28,6 @@ Type: Object
   Enable/disable JSON-Schema validation on change.
 - `code.validation.jsonSchema.logMissingSchemaAsError` - default: false
 - `code.validation.jsonSchema.logMissingSchemaAsWarning` - default: true
-
-#### `code.validation.stylelint`
-
-Type: Object
-
-- `code.validation.stylelint.live` - default: false
-
-Enable/disable CSS linting on change.
 
 ## Nitro
 

--- a/packages/project-nitro/config/default.js
+++ b/packages/project-nitro/config/default.js
@@ -10,9 +10,6 @@ const baseConfig = require('@nitro/app/app/core/config');
 const defaultConfig = {
 	code: {
 		validation: {
-			eslint: {
-				live: false,
-			},
 			htmllint: {
 				// enabling this live validation slows down rendering
 				live: false,
@@ -21,9 +18,6 @@ const defaultConfig = {
 				live: true,
 				logMissingSchemaAsError: false,
 				logMissingSchemaAsWarning: true,
-			},
-			stylelint: {
-				live: false,
 			},
 		},
 	},

--- a/packages/project-nitro/config/webpack/options.js
+++ b/packages/project-nitro/config/webpack/options.js
@@ -3,12 +3,9 @@ const validThemes = config.has('themes') && Array.isArray(config.get('themes')) 
 const theme = process.env.THEME ? process.env.THEME : validThemes.find((theme) => theme.isDefault).id;
 const options = {
 	rules: {
-		js: {
-			eslint: config.get('code.validation.eslint.live'),
-		},
+		js: true,
 		ts: false,
 		scss: {
-			stylelint: config.get('code.validation.stylelint.live'),
 			publicPath: '../',
 			implementation: require('node-sass'),
 		},

--- a/packages/project-nitro/project/docs/nitro-config.md
+++ b/packages/project-nitro/project/docs/nitro-config.md
@@ -12,14 +12,6 @@ the main nodes from nitro: `code`, `nitro`,`server`, `gulp`, `feature`, `exporte
 
 ### Validation
 
-#### `code.validation.eslint`
-
-Type: Object
-
-- `code.validation.eslint.live` - default: false
-
-Enable/disable JavaScript linting on change.
-
 #### `code.validation.htmllint`
 
 Type: Object
@@ -36,14 +28,6 @@ Type: Object
   Enable/disable JSON-Schema validation on change.
 - `code.validation.jsonSchema.logMissingSchemaAsError` - default: false
 - `code.validation.jsonSchema.logMissingSchemaAsWarning` - default: true
-
-#### `code.validation.stylelint`
-
-Type: Object
-
-- `code.validation.stylelint.live` - default: false
-
-Enable/disable CSS linting on change.
 
 ## Nitro
 

--- a/packages/project-prod/config/default.js
+++ b/packages/project-prod/config/default.js
@@ -10,9 +10,6 @@ const baseConfig = require('@nitro/app/app/core/config');
 const defaultConfig = {
 	code: {
 		validation: {
-			eslint: {
-				live: false,
-			},
 			htmllint: {
 				live: true,
 			},
@@ -20,9 +17,6 @@ const defaultConfig = {
 				live: true,
 				logMissingSchemaAsError: false,
 				logMissingSchemaAsWarning: true,
-			},
-			stylelint: {
-				live: false,
 			},
 		},
 	},


### PR DESCRIPTION
## Purpose of this pull request?

- removing live linting that no longer makes sense

The pull request refers to the:

- generator (generator-nitro)
- nitro webpack config (@nitro/webpack)
- example nitro projects

## What changes did you make?

- Remove config params
  - validation:
    - `code.validation.eslint.live`
    - `code.validation.stylelint.live`
  - webpack
    - `options.rules.scss.stylelint`
    - `options.rules.js.eslint`
- Example & Documentation changes

If the parameters are still configured, they are simply ignored.